### PR TITLE
Update calibrate_drive.py

### DIFF
--- a/setup/calibrate_drive.py
+++ b/setup/calibrate_drive.py
@@ -346,7 +346,7 @@ if __name__ == '__main__':
         # First calibration - ODrive
         print("\n\033[1;36mStep 1: ODrive Motor Calibration\033[0m")
         if not calibrate_odrive():
-            sys.exit(1)
+            print(f"{RED}ODrive calibration failed, continuing to motor direction test...{RESET}")
             
         # Second calibration - Motor direction
         print("\n\033[1;36mStep 2: Motor Direction Calibration\033[0m")


### PR DESCRIPTION
Suggesting this fix so that users are given the option to calibrate the motor direction even if they don't need to calibrate odrive (valuable for users like me who have to reflash the SSD card often & therefore need to regenerate the gyro file)